### PR TITLE
Implement "modulo" function for uint types

### DIFF
--- a/src/ops.sw
+++ b/src/ops.sw
@@ -160,6 +160,46 @@ impl Divide for u8 {
     }
 }
 
+pub trait Mod {
+    fn modulo(self, other: Self) -> Self;
+}
+
+impl Mod for u64 {
+    fn modulo(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            mod r3 r1 r2;
+            r3: u64
+        }
+    }
+}
+
+impl Mod for u32 {
+    fn modulo(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            mod r3 r1 r2;
+            r3: u32
+        }
+    }
+}
+
+impl Mod for u16 {
+    fn modulo(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            mod r3 r1 r2;
+            r3: u16
+        }
+    }
+}
+
+impl Mod for u8 {
+    fn modulo(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            mod r3 r1 r2;
+            r3: u8
+        }
+    }
+}
+
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;


### PR DESCRIPTION
Implemented modulo function using a "Mod" trait, has worked in my tests. Followed the code style of the other ops in just wrapping the opcode in a callable function with an explicit return type. 

Adding tests here in case its helpful for CI
 
main.sw
 
 
```
contract;

abi TestContract {
  fn sqrtu64(gas_: u64, amount_: u64, coin_: b256, amount: u64) -> u64;
  fn sqrtu32(gas_: u64, amount_: u64, coin_: b256, amount: u32) -> u64;
  fn sqrtu16(gas_: u64, amount_: u64, coin_: b256, amount: u16) -> u64;
  fn sqrtu8(gas_: u64, amount_: u64, coin_: b256, amount: u8) -> u64;

}

impl TestContract for Contract {
  fn sqrtu64(gas_: u64, amount_: u64, color_: b256, amount: u64) -> u64 {
    let value:u64 = amount % 10;

    value
  }
  fn sqrtu32(gas_: u64, amount_: u64, color_: b256, amount: u32) -> u64 {
    let value:u32 = amount % 10;

    value
  }
  fn sqrtu16(gas_: u64, amount_: u64, color_: b256, amount: u16) -> u64 {
    let value:u16 = amount % 10;

    value
  }
  fn sqrtu8(gas_: u64, amount_: u64, color_: b256, amount: u8) -> u64 {
    let value:u8 = amount % 10;

    value
  }
}
```

and 

harness.rs

```
use fuel_tx::Salt;
use fuels_abigen_macro::abigen;
use fuels_rs::contract::Contract;
use rand::rngs::StdRng;
use rand::{Rng, SeedableRng};

// Generate Rust bindings from our contract JSON ABI
abigen!(MyContract, "./my-contract-abi.json");

#[tokio::test]
async fn harness() {
    let rng = &mut StdRng::seed_from_u64(2322u64);

    // Build the contract
    let salt: [u8; 32] = rng.gen();
    let salt = Salt::from(salt);
    let compiled = Contract::compile_sway_contract("./", salt).unwrap();

    // Launch a local network and deploy the contract
    let (client, contract_id) = Contract::launch_and_deploy(&compiled).await.unwrap();

    let contract_instance = MyContract::new(compiled, client);

    // Call `initialize_counter()` method in our deployed contract.
    // Note that, here, you get type-safety for free!
    let result = contract_instance
        .sqrtu32(100)
        .call()
        .await
        .unwrap();

    assert_eq!(0, result);

    // Call `increment_counter()` method in our deployed contract.
    let result = contract_instance
        .sqrtu64(15)
        .call()
        .await
        .unwrap();

    assert_eq!(5, result);
}
```

tested on forc version v0.1.9