### PR TITLE
Add in rsh and lsh operations

### DIFF
--- a/src/ops.sw
+++ b/src/ops.sw
@@ -200,6 +200,71 @@ impl Mod for u8 {
     }
 }
 
+pub trait Shiftable {
+    fn lsh(self, other: Self) -> Self;
+    fn rsh(self, other: Self) -> Self;
+}
+
+impl Shiftable for u64 {
+    fn lsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            sll r3 r1 r2;
+            r3: u64
+        }
+    }
+    fn rsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            srl r3 r1 r2;
+            r3: u64
+        }
+    }
+}
+
+impl Shiftable for u32 {
+    fn lsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            sll r3 r1 r2;
+            r3: u32
+        }
+    }
+    fn rsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            srl r3 r1 r2;
+            r3: u32
+        }
+    }
+}
+
+impl Shiftable for u16 {
+    fn lsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            sll r3 r1 r2;
+            r3: u16
+        }
+    }
+    fn rsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            srl r3 r1 r2;
+            r3: u16
+        }
+    }
+}
+
+impl Shiftable for u8 {
+    fn lsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            sll r3 r1 r2;
+            r3: u8
+        }
+    }
+    fn rsh(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            srl r3 r1 r2;
+            r3: u8
+        }
+    }
+}
+
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
@@ -220,6 +285,8 @@ pub trait Ord {
         }
     }
 }
+
+
 
 impl Ord for u64 {
     fn gt(self, other: Self) -> bool {

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -286,8 +286,6 @@ pub trait Ord {
     }
 }
 
-
-
 impl Ord for u64 {
     fn gt(self, other: Self) -> bool {
         asm(r1: self, r2: other, r3) {


### PR DESCRIPTION
Added in the lsh and rsh operators to the core sway now that [FuelLabs/sway/pull/588](https://github.com/FuelLabs/sway/pull/588) is fixed. I will added tests to core sway library after I try to get >> and << implemented. Tested this though locally on forc 0.2.1 and it works fine calling .rsh on a uint64. Also implemented in the same way all other traits have been for the core library.

Hopefully his can provide people looking for bit shifting functionality with something until >> and << are implemented