### PR TITLE
Split `eq` out of `Ord` and put it in `Eq`

### DIFF
--- a/src/ops.sw
+++ b/src/ops.sw
@@ -319,21 +319,7 @@ impl Eq for b256 {
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
-} {
-    fn le(self, other: Self) -> bool {
-        self.lt(other) || self.eq(other)
-    }
-    fn ge(self, other: Self) -> bool {
-        self.gt(other) || self.eq(other)
-    }
-    fn neq(self, other: Self) -> bool {
-        // TODO unary operator negation
-        if self.eq(other) {
-            false
-        } else {
-            true
-        }
-    }
+    fn le(self, other: Self) -> bool;
 }
 
 impl Ord for u64 {
@@ -347,6 +333,15 @@ impl Ord for u64 {
         asm(r1: self, r2: other, r3) {
             lt r3 r1 r2;
             r3: bool
+        }
+    }
+    fn le(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4 ,r5){
+            lt r3 r1 r2;
+            eq r4 r1 r2;
+            or r5 r3 r4;
+
+            r5: bool
         }
     }
 }
@@ -364,6 +359,15 @@ impl Ord for u32 {
             r3: bool
         }
     }
+    fn le(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4 ,r5){
+            lt r3 r1 r2;
+            eq r4 r1 r2;
+            or r5 r3 r4;
+
+            r5: bool
+        }
+    }
 }
 
 impl Ord for u16 {
@@ -379,6 +383,15 @@ impl Ord for u16 {
             r3: bool
         }
     }
+    fn le(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4 ,r5){
+            lt r3 r1 r2;
+            eq r4 r1 r2;
+            or r5 r3 r4;
+
+            r5: bool
+        }
+    }
 }
 
 impl Ord for u8 {
@@ -392,6 +405,15 @@ impl Ord for u8 {
         asm(r1: self, r2: other, r3) {
             lt r3 r1 r2;
             r3: bool
+        }
+    }
+    fn le(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4 ,r5){
+            lt r3 r1 r2;
+            eq r4 r1 r2;
+            or r5 r3 r4;
+
+            r5: bool
         }
     }
 }

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -319,7 +319,6 @@ impl Eq for b256 {
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
-    fn le(self, other: Self) -> bool;
 } {
     fn le(self, other: Self) -> bool {
         asm(r1: self, r2: other, r3, r4) {
@@ -342,11 +341,13 @@ pub trait Ord {
 
         // Fix this ugly block which uses assembly rather than 
         // importing and utilizing an eq method
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2
-        }
+        let is_equal:bool = asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
 
-        if r3 {
+            r3: bool
+        };
+
+        if is_equal {
             false
         } else {
             true

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -332,16 +332,16 @@ pub trait Ord {
         asm(r1: self, r2: other, r3, r4) {
             lt r3 r1 r2;
             not r4 r3;
-            
+
             r4: bool
         }
     }
     fn neq(self, other: Self) -> bool {
         // TODO unary operator negation
 
-        // Fix this ugly block which uses assembly rather than 
+        // Fix this ugly block which uses assembly rather than
         // importing and utilizing an eq method
-        let is_equal:bool = asm(r1: self, r2: other, r3) {
+        let is_equal: bool = asm(r1: self, r2: other, r3) {
             eq r3 r1 r2;
 
             r3: bool

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -265,10 +265,60 @@ impl Shiftable for u8 {
     }
 }
 
+pub trait Eq {
+    fn eq(self, other: Self) -> bool;
+}
+
+impl Eq for u64 {
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
+impl Eq for u32 {
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
+impl Eq for u16 {
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
+impl Eq for u8 {
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
+impl Eq for b256 {
+    fn eq(self, other: Self) -> bool {
+        // Both self and other are addresses of the values, so we can use MEQ.
+        asm(r1: self, r2: other, r3, r4) {
+            addi r3 zero i32;
+            meq r4 r1 r2 r3;
+            r4: bool
+        }
+    }
+}
+
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
-    fn eq(self, other: Self) -> bool;
 } {
     fn le(self, other: Self) -> bool {
         self.lt(other) || self.eq(other)
@@ -299,12 +349,6 @@ impl Ord for u64 {
             r3: bool
         }
     }
-    fn eq(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2;
-            r3: bool
-        }
-    }
 }
 
 impl Ord for u32 {
@@ -317,12 +361,6 @@ impl Ord for u32 {
     fn lt(self, other: Self) -> bool {
         asm(r1: self, r2: other, r3) {
             lt r3 r1 r2;
-            r3: bool
-        }
-    }
-    fn eq(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2;
             r3: bool
         }
     }
@@ -362,12 +400,6 @@ impl Ord for u8 {
             r3: bool
         }
     }
-    fn eq(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2;
-            r3: bool
-        }
-    }
 }
 
 // Should this be a trait eventually? Do we want to allow people to customize what `!` does?
@@ -381,14 +413,6 @@ pub fn not(a: bool) -> bool {
 }
 
 impl b256 {
-    fn eq(self, other: Self) -> bool {
-        // Both self and other are addresses of the values, so we can use MEQ.
-        asm(r1: self, r2: other, r3, r4) {
-            addi r3 zero i32;
-            meq r4 r1 r2 r3;
-            r4: bool
-        }
-    }
     fn neq(self, other: Self) -> bool {
         // Both self and other are addresses of the values, so we can use MEQ.
         not(asm(r1: self, r2: other, r3, r4) {

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -320,6 +320,38 @@ pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
     fn le(self, other: Self) -> bool;
+} {
+    fn le(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4) {
+            gt r3 r1 r2;
+            not r4 r3;
+
+            r4: bool
+        }
+    }
+    fn ge(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3, r4) {
+            lt r3 r1 r2;
+            not r4 r3;
+            
+            r4: bool
+        }
+    }
+    fn neq(self, other: Self) -> bool {
+        // TODO unary operator negation
+
+        // Fix this ugly block which uses assembly rather than 
+        // importing and utilizing an eq method
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2
+        }
+
+        if r3 {
+            false
+        } else {
+            true
+        }
+    }
 }
 
 impl Ord for u64 {
@@ -333,15 +365,6 @@ impl Ord for u64 {
         asm(r1: self, r2: other, r3) {
             lt r3 r1 r2;
             r3: bool
-        }
-    }
-    fn le(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3, r4 ,r5){
-            lt r3 r1 r2;
-            eq r4 r1 r2;
-            or r5 r3 r4;
-
-            r5: bool
         }
     }
 }
@@ -359,15 +382,6 @@ impl Ord for u32 {
             r3: bool
         }
     }
-    fn le(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3, r4 ,r5){
-            lt r3 r1 r2;
-            eq r4 r1 r2;
-            or r5 r3 r4;
-
-            r5: bool
-        }
-    }
 }
 
 impl Ord for u16 {
@@ -383,15 +397,6 @@ impl Ord for u16 {
             r3: bool
         }
     }
-    fn le(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3, r4 ,r5){
-            lt r3 r1 r2;
-            eq r4 r1 r2;
-            or r5 r3 r4;
-
-            r5: bool
-        }
-    }
 }
 
 impl Ord for u8 {
@@ -405,15 +410,6 @@ impl Ord for u8 {
         asm(r1: self, r2: other, r3) {
             lt r3 r1 r2;
             r3: bool
-        }
-    }
-    fn le(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3, r4 ,r5){
-            lt r3 r1 r2;
-            eq r4 r1 r2;
-            or r5 r3 r4;
-
-            r5: bool
         }
     }
 }

--- a/src/ops.sw
+++ b/src/ops.sw
@@ -379,12 +379,6 @@ impl Ord for u16 {
             r3: bool
         }
     }
-    fn eq(self, other: Self) -> bool {
-        asm(r1: self, r2: other, r3) {
-            eq r3 r1 r2;
-            r3: bool
-        }
-    }
 }
 
 impl Ord for u8 {


### PR DESCRIPTION
I've done a fair bit of testing on this, optimized the ge and le methods with some in-lining of assembly, not a perfect solution but presently there isn't a neater way to do this in Sway, and with how core works no imported methods can be used for abstraction. But until this then this solution should move out that trait so @nfurfaro can begin work on his end. Lmk if there is anything I missed, tried to catch everything I could though