### PR TITLE
change author to authors in Forc.toml

### DIFF
--- a/Forc.toml
+++ b/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "core"


### PR DESCRIPTION
Updating 'Forc.toml' to use `authors` instead of `author`. This enables compatibility with the change being made in this PR https://github.com/FuelLabs/sway/pull/822