### PR TITLE
Implement Eq for bool

### DIFF
--- a/src/ops.sw
+++ b/src/ops.sw
@@ -269,6 +269,15 @@ pub trait Eq {
     fn eq(self, other: Self) -> bool;
 }
 
+impl Eq for bool {
+    fn eq(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            eq r3 r1 r2;
+            r3: bool
+        }
+    }
+}
+
 impl Eq for u64 {
     fn eq(self, other: Self) -> bool {
         asm(r1: self, r2: other, r3) {


### PR DESCRIPTION
Basically, the same function body as all the other `u*` implementations of `Eq`.